### PR TITLE
Drop Linux runner version to support more libc versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,8 @@ jobs:
         shell: bash
         run: |
           ARCHIVE_FILE=seiri-${PLATFORM_TARGET}.zip
-          7z a $ARCHIVE_FILE ./target/${PLATFORM_TARGET}/release/seiri-cli.exe
+          cp ./target/${PLATFORM_TARGET}/release/seiri-cli.exe ./seiri.exe
+          7z a $ARCHIVE_FILE ./seiri.exe
           sha256sum $ARCHIVE_FILE > $ARCHIVE_FILE.sha256
         env:
           PLATFORM_TARGET: ${{ matrix.platform.target }}


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

# Pull Request

## Initial Checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

## Related Issue(s)

#114 

## Description of Changes

* Added support for 32-bit Windows
* Added support for x64 macOS
* Downgrade runner versions

<!--do not edit: pr-->
