### PR TITLE
Fix crates.io publish workflow when not using dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,8 +225,15 @@ jobs:
                                   libgl1-mesa-dev ttf-mscorefonts-installer \
                                   libfreetype6-dev libfontconfig-dev
 
-      - name: Publish to crates.io
+      - name: Publish to crates.io (dry run)
+        if: inputs.tag == 'dry-run'
         run: |
           cargo publish \
             --token ${{ secrets.CARGO_REGISTRY_TOKEN }} \
-            ${{ inputs.tag == 'dry-run' && '--dry-run' }}
+            --dry-run
+
+      - name: Publish to crates.io
+        if: inputs.tag != 'dry-run'
+        run: |
+          cargo publish \
+            --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## What
Fixes an issue where `cargo publish` received a `false` argument when the workflow was not run in dry-run mode.

## Why
GitHub Actions expressions return `false` when the condition is not met, which caused the publish command to fail.

## How
Split the publish step into two separate steps using step-level `if:` conditions:
- one for dry-run
- one for actual publishing

This avoids injecting invalid arguments into the shell command.

## Checklist
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct
- [x] This change is minimal and scoped
- [x] No tests are required for workflow-only changes

## Related Issue
Fixes #125
