### PR TITLE
Fix major defects in graph construction and Sugiyama layout

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -921,11 +921,9 @@ mod tests {
         let tip = edge_tip_at_node_boundary(p, p, 20.0);
         assert_eq!(tip, p);
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    // --- build_dependency_graph (layout must see the real dependency targets) ---
+
     use crate::core::defs::{FileNode, Language};
 
     fn make_node(path: &str, deps: &[&str]) -> GraphNode {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -6,6 +6,7 @@ use eframe::egui;
 use egui::{Pos2, Rect, Response, Sense, Ui, Vec2, pos2, vec2};
 use petgraph::{Graph, graph::NodeIndex};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 mod camera;
 mod culling;
@@ -21,6 +22,31 @@ fn edge_tip_at_node_boundary(from: Pos2, to: Pos2, radius: f32) -> Pos2 {
         return to;
     }
     to - delta.normalized() * radius
+}
+
+/// Build a petgraph mirroring the real dependency edges between `graph_nodes`,
+/// resolving each edge's file path to its target's actual index rather than
+/// assuming an edge's position within its source node's edge list matches the
+/// target's index in `graph_nodes`.
+fn build_dependency_graph(graph_nodes: &[GraphNode]) -> Graph<(), ()> {
+    let mut graph = Graph::new();
+    let node_indices: Vec<NodeIndex> = graph_nodes.iter().map(|_| graph.add_node(())).collect();
+
+    let path_to_index: HashMap<&PathBuf, usize> = graph_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, node)| (node.data().file(), i))
+        .collect();
+
+    for (from_idx, node) in graph_nodes.iter().enumerate() {
+        for edge_file in node.edges() {
+            if let Some(&to_idx) = path_to_index.get(edge_file) {
+                graph.add_edge(node_indices[from_idx], node_indices[to_idx], ());
+            }
+        }
+    }
+
+    graph
 }
 
 pub struct SeiriGraph {
@@ -94,21 +120,9 @@ impl SeiriGraph {
             return;
         }
 
-        // Create a graph for layout
-        let mut graph = Graph::new();
-        let mut node_indices = Vec::with_capacity(n);
-
-        // Add nodes
-        for _ in 0..n {
-            node_indices.push(graph.add_node(()));
-        }
-
-        // Add edges based on dependencies
-        for (from_idx, node) in self.graph_nodes.iter().enumerate() {
-            for (dep_idx, _edge) in node.edges().iter().enumerate() {
-                graph.add_edge(node_indices[from_idx], node_indices[dep_idx], ());
-            }
-        }
+        // Build a graph mirroring the real dependency edges for layout
+        let graph = build_dependency_graph(&self.graph_nodes);
+        let node_indices: Vec<NodeIndex> = graph.node_indices().collect();
 
         // Get layout positions
         let layout = layout::create_layout(self.layout_type);
@@ -906,5 +920,65 @@ mod tests {
         let p = pos2(10.0, 10.0);
         let tip = edge_tip_at_node_boundary(p, p, 20.0);
         assert_eq!(tip, p);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::defs::{FileNode, Language};
+
+    fn make_node(path: &str, deps: &[&str]) -> GraphNode {
+        let file_node = FileNode::new(
+            PathBuf::from(path),
+            0,
+            Language::Rust,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        );
+        GraphNode::new(file_node, deps.iter().map(PathBuf::from).collect())
+    }
+
+    // node 0 has a single dependency on node 2. The buggy implementation
+    // wired edges by the dependency's position within its source node's own
+    // edge list (always 0 here) rather than the target's real index, which
+    // would incorrectly self-loop node 0 instead of pointing at node 2.
+    #[test]
+    fn build_dependency_graph_resolves_edges_by_target_file_not_by_list_position() {
+        let graph_nodes = vec![
+            make_node("a.rs", &["c.rs"]),
+            make_node("b.rs", &[]),
+            make_node("c.rs", &[]),
+        ];
+
+        let graph = build_dependency_graph(&graph_nodes);
+
+        assert!(
+            graph.contains_edge(NodeIndex::new(0), NodeIndex::new(2)),
+            "edge should point at the real target (c.rs, index 2), not the edge's list position (index 0)"
+        );
+        assert!(!graph.contains_edge(NodeIndex::new(0), NodeIndex::new(0)));
+        assert_eq!(graph.edge_count(), 1);
+    }
+
+    #[test]
+    fn build_dependency_graph_resolves_multiple_edges_independently() {
+        // b depends on both a (index 0) and c (index 2); with the buggy
+        // list-position logic this would wire b->a (index 0, correct by
+        // coincidence) and b->b (index 1, wrong: should be b->c).
+        let graph_nodes = vec![
+            make_node("a.rs", &[]),
+            make_node("b.rs", &["a.rs", "c.rs"]),
+            make_node("c.rs", &[]),
+        ];
+
+        let graph = build_dependency_graph(&graph_nodes);
+
+        assert!(graph.contains_edge(NodeIndex::new(1), NodeIndex::new(0)));
+        assert!(graph.contains_edge(NodeIndex::new(1), NodeIndex::new(2)));
+        assert!(!graph.contains_edge(NodeIndex::new(1), NodeIndex::new(1)));
+        assert_eq!(graph.edge_count(), 2);
     }
 }

--- a/src/layout/sugiyama.rs
+++ b/src/layout/sugiyama.rs
@@ -1,18 +1,20 @@
+//! Sugiyama graph layout. See: https://en.wikipedia.org/wiki/Layered_graph_drawing
+
 use crate::layout::Layout;
 use petgraph::Direction;
 use petgraph::graph::{Graph, NodeIndex};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 /// Configuration options for Sugiyama layout
 #[derive(Debug, Clone)]
 pub struct SugiyamaConfig {
-    /// Maximum number of iterations for crossing minimization
+    /// Maximum number of iterations for crossing minimization.
     pub max_iterations: usize,
-    /// Minimum horizontal distance between nodes in the same layer
+    /// Minimum horizontal distance between nodes in the same layer.
     pub node_spacing: f32,
-    /// Vertical distance between layers
+    /// Vertical distance between layers.
     pub layer_spacing: f32,
-    /// Scaling factor for the entire layout
+    /// Scaling factor for the entire layout.
     pub scale_factor: f32,
 }
 
@@ -48,7 +50,7 @@ impl LayeredNode {
     }
 }
 
-/// Sugiyama (hierarchical) layout implementation
+/// Sugiyama (hierarchical) layout implementation.
 pub struct SugiyamaLayout {
     config: SugiyamaConfig,
 }
@@ -58,11 +60,11 @@ impl SugiyamaLayout {
         Self { config }
     }
 
-    /// Create a directed acyclic graph by removing a minimal set of edges
+    /// Create a directed acyclic graph by removing a minimal set of edges.
     fn make_dag(&self, graph: &Graph<(), ()>) -> Graph<(), ()> {
         let mut dag = graph.clone();
 
-        // Find all cycles and break them
+        // find all cycles and break them
         for start_node in graph.node_indices() {
             let mut visited = HashSet::new();
             let mut path = Vec::new();
@@ -86,7 +88,7 @@ impl SugiyamaLayout {
                     if !visited.contains(&neighbor) {
                         dfs(neighbor, graph, visited, path, on_stack);
                     } else if on_stack.contains(&neighbor) {
-                        // Found a cycle, remove the last edge
+                        // found a cycle, remove the last edge
                         if let Some(&last) = path.last()
                             && let Some(edge) = graph.find_edge(last, neighbor)
                         {
@@ -107,50 +109,27 @@ impl SugiyamaLayout {
         dag
     }
 
-    /// Assign vertices to layers using longest path algorithm
+    /// Assign vertices to layers using the longest-path algorithm: each
+    /// node's layer is the maximum of `predecessor_layer + 1` over all of
+    /// its incoming edges, computed via a single pass over a topological
+    /// order of the (already acyclic) graph.
     fn assign_layers(&self, dag: &Graph<(), ()>) -> Vec<Vec<LayeredNode>> {
         let mut layers = Vec::new();
         let mut node_layers = HashMap::new();
 
-        // First pass: assign minimum layers based on longest path from a root
-        let mut queue = VecDeque::new();
-        let mut roots: Vec<_> = dag
-            .node_indices()
-            .filter(|&n| dag.neighbors_directed(n, Direction::Incoming).count() == 0)
-            .collect();
+        let topo_order = petgraph::algo::toposort(dag, None).unwrap_or_else(|_| {
+            // Should not happen since `dag` has already had its cycles broken,
+            // but fall back to insertion order rather than panicking
+            dag.node_indices().collect()
+        });
 
-        // If no roots found, use nodes with minimal incoming edges
-        if roots.is_empty() {
-            let min_in_degree = dag
-                .node_indices()
-                .map(|n| dag.neighbors_directed(n, Direction::Incoming).count())
-                .min()
-                .unwrap_or(0);
-            roots.extend(dag.node_indices().filter(|&n| {
-                dag.neighbors_directed(n, Direction::Incoming).count() == min_in_degree
-            }));
-        }
-
-        // Initialize roots to layer 0
-        for &root in &roots {
-            queue.push_back(root);
-            node_layers.insert(root, 0);
-        }
-
-        // BFS to assign layers
-        while let Some(node) = queue.pop_front() {
-            let current_layer = *node_layers.get(&node).unwrap();
-
-            for neighbor in dag.neighbors_directed(node, Direction::Outgoing) {
-                let next_layer = current_layer + 1;
-                match node_layers.get(&neighbor) {
-                    Some(&existing_layer) if existing_layer <= next_layer => continue,
-                    _ => {
-                        node_layers.insert(neighbor, next_layer);
-                        queue.push_back(neighbor);
-                    }
-                }
-            }
+        for node in topo_order {
+            let layer = dag
+                .neighbors_directed(node, Direction::Incoming)
+                .filter_map(|pred| node_layers.get(&pred))
+                .max()
+                .map_or(0, |&max_pred_layer| max_pred_layer + 1);
+            node_layers.insert(node, layer);
         }
 
         // Handle any remaining unassigned nodes (in case of disconnected components)
@@ -177,7 +156,7 @@ impl SugiyamaLayout {
         layers
     }
 
-    /// Add dummy nodes for edges that span multiple layers
+    /// Add dummy nodes for edges that span multiple layers.
     fn expand_long_edges(&self, dag: &mut Graph<(), ()>, layers: &mut [Vec<LayeredNode>]) {
         let mut new_edges = Vec::new();
         let mut dummy_nodes = Vec::new();
@@ -221,7 +200,7 @@ impl SugiyamaLayout {
         }
     }
 
-    /// Count crossings between two adjacent layers
+    /// Count crossings between two adjacent layers.
     fn count_crossings(
         &self,
         layer1: &[LayeredNode],
@@ -250,7 +229,7 @@ impl SugiyamaLayout {
         crossings
     }
 
-    /// Reduce edge crossings between layers
+    /// Reduce edge crossings between layers.
     fn reduce_crossings(&self, layers: &mut [Vec<LayeredNode>], dag: &Graph<(), ()>) {
         for _ in 0..self.config.max_iterations {
             let mut improved = false;
@@ -359,19 +338,56 @@ impl Layout for SugiyamaLayout {
             return HashMap::new();
         }
 
-        // Step 1: Make the graph acyclic
+        // step 1: make the graph acyclic
         let mut dag = self.make_dag(graph);
 
-        // Step 2: Assign vertices to layers
+        // step 2: assign vertices to layers
         let mut layers = self.assign_layers(&dag);
 
-        // Step 3: Add dummy nodes for long edges
+        // step 3: add dummy nodes for long edges
         self.expand_long_edges(&mut dag, &mut layers);
 
-        // Step 4: Reduce edge crossings
+        // step 4: reduce edge crossings
         self.reduce_crossings(&mut layers, &dag);
 
-        // Step 5: Assign coordinates
+        // step 5: assign coordinates
         self.assign_coordinates(&dag, &layers)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Diamond-shaped dependency: A->B, A->C->B. B must land in the layer
+    /// one past its deepest predecessor (C), not the layer from the first
+    /// edge visited (the direct A->B edge).
+    #[test]
+    fn assign_layers_uses_longest_path_for_diamond() {
+        let layout = SugiyamaLayout::new(SugiyamaConfig::default());
+        let mut graph: Graph<(), ()> = Graph::new();
+        let a = graph.add_node(());
+        let b = graph.add_node(());
+        let c = graph.add_node(());
+        graph.add_edge(a, b, ());
+        graph.add_edge(a, c, ());
+        graph.add_edge(c, b, ());
+
+        let layers = layout.assign_layers(&graph);
+
+        let layer_of = |id: NodeIndex| -> usize {
+            layers
+                .iter()
+                .position(|layer| layer.iter().any(|n| n.id == id))
+                .expect("node should be assigned a layer")
+        };
+
+        assert_eq!(layer_of(a), 0);
+        assert_eq!(layer_of(c), 1);
+        assert_eq!(
+            layer_of(b),
+            2,
+            "B must be promoted to layer 2 via the longer A->C->B path"
+        );
     }
 }

--- a/src/layout/sugiyama.rs
+++ b/src/layout/sugiyama.rs
@@ -328,6 +328,27 @@ impl SugiyamaLayout {
             }
             coordinates = adjusted_coords.clone();
         }
+
+        // refinement above pulls nodes toward their neighbors' x
+        // coordinates with no lower bound, which can collapse siblings in
+        // the same layer on top of each other; restore `node_spacing` as a
+        // hard minimum by sweeping each layer left-to-right in x order and
+        // pushing any node that ended up too close to its left neighbor
+        let min_gap = self.config.node_spacing * self.config.scale_factor;
+        for layer in layers.iter() {
+            let mut ids: Vec<NodeIndex> = layer.iter().map(|node| node.id).collect();
+            ids.sort_by(|&a, &b| coordinates[&a].0.partial_cmp(&coordinates[&b].0).unwrap());
+
+            for pair in ids.windows(2) {
+                let (left, right) = (pair[0], pair[1]);
+                let min_x = coordinates[&left].0 + min_gap;
+                if coordinates[&right].0 < min_x {
+                    let y = coordinates[&right].1;
+                    coordinates.insert(right, (min_x, y));
+                }
+            }
+        }
+
         coordinates
     }
 }
@@ -389,5 +410,36 @@ mod tests {
             2,
             "B must be promoted to layer 2 via the longer A->C->B path"
         );
+    }
+
+    /// `node_spacing` is documented as "Minimum horizontal distance between
+    /// nodes in the same layer". A hub node with several children pulls all
+    /// of them toward the same x during the connectivity-based refinement
+    /// pass; that pass must not be allowed to collapse siblings closer than
+    /// the configured minimum.
+    #[test]
+    fn assign_coordinates_respects_minimum_node_spacing_after_refinement() {
+        let config = SugiyamaConfig::default();
+        let layout = SugiyamaLayout::new(config.clone());
+        let mut graph: Graph<(), ()> = Graph::new();
+        let hub = graph.add_node(());
+        let children: Vec<_> = (0..5).map(|_| graph.add_node(())).collect();
+        for &c in &children {
+            graph.add_edge(hub, c, ());
+        }
+
+        let positions = layout.layout(&graph);
+
+        let min_gap = config.node_spacing * config.scale_factor;
+        let mut child_xs: Vec<f32> = children.iter().map(|c| positions[c].0).collect();
+        child_xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        for pair in child_xs.windows(2) {
+            let gap = pair[1] - pair[0];
+            assert!(
+                gap >= min_gap - 1e-3,
+                "siblings collapsed too close together: gap {gap} < configured minimum {min_gap}"
+            );
+        }
     }
 }


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

# Pull Request

## Initial Checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

## Related Issue(s)
#141, #144

## Description of Changes

- Fix critical defect that was constructing random edges used for layouts and metrics
- Fix diamond imports by performing topological sort before computing longest path
- Add minimum-separation constraint to Sugiyama drawing layout

<!--do not edit: pr-->
