### PR TITLE
Prevent import resolution outside project roots

### DIFF
--- a/src/core/resolvers.rs
+++ b/src/core/resolvers.rs
@@ -11,6 +11,17 @@ pub mod python;
 pub mod rust;
 pub mod typescript;
 
+fn is_within_project(candidate: &Path, project_root: &Path) -> bool {
+    let Ok(candidate) = candidate.canonicalize() else {
+        return false;
+    };
+    let Ok(project_root) = project_root.canonicalize() else {
+        return false;
+    };
+
+    candidate.starts_with(project_root)
+}
+
 /// Module resolution trait
 pub trait LanguageResolver {
     /// Build module mapping for this language
@@ -78,6 +89,7 @@ impl GraphBuilder {
                     }
                     if let Some(target_file) = resolver.resolve_import(import.path(), file_path)
                         && target_file != *file_path
+                        && node_map.contains_key(&target_file)
                         && !resolved_imports.contains(&target_file)
                     {
                         edges.push(target_file.clone());

--- a/src/core/resolvers/cpp.rs
+++ b/src/core/resolvers/cpp.rs
@@ -1,4 +1,4 @@
-use super::LanguageResolver;
+use super::{LanguageResolver, is_within_project};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -294,7 +294,7 @@ impl CppResolver {
         // Search for the include file in order of priority
         for search_dir in search_dirs {
             let candidate = search_dir.join(&normalized);
-            if candidate.exists() && candidate.is_file() {
+            if candidate.is_file() && is_within_project(&candidate, &self.project_root) {
                 return Some(candidate);
             }
 
@@ -303,7 +303,7 @@ impl CppResolver {
                 let extensions = vec![".h", ".hpp", ".hxx", ".h++", ".cc", ".cpp", ".cxx", ".c++"];
                 for ext in extensions {
                     let with_ext = search_dir.join(format!("{}{}", normalized, ext));
-                    if with_ext.exists() && with_ext.is_file() {
+                    if with_ext.is_file() && is_within_project(&with_ext, &self.project_root) {
                         return Some(with_ext);
                     }
                 }
@@ -511,6 +511,31 @@ mod tests {
         // Request without extension - resolver should find it with .hpp
         let result = resolver.find_include_file("include/helper", &source_file);
         assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_find_include_file_rejects_parent_traversal() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let project_root = temp_dir.path().join("project");
+        let source_dir = project_root.join("src");
+        fs::create_dir_all(&source_dir).expect("Failed to create source dir");
+
+        let outside_file = temp_dir.path().join("outside.h");
+        fs::write(&outside_file, "// outside").expect("Failed to write outside file");
+        let source_file = source_dir.join("main.cpp");
+        fs::write(&source_file, "#include \"../../outside.h\"")
+            .expect("Failed to write source file");
+
+        let mut resolver = CppResolver::new();
+        resolver.build_module_map(&[], &project_root);
+
+        assert_eq!(
+            resolver.find_include_file("../../outside.h", &source_file),
+            None
+        );
     }
 
     #[test]

--- a/src/core/resolvers/python.rs
+++ b/src/core/resolvers/python.rs
@@ -1,4 +1,4 @@
-use super::LanguageResolver;
+use super::{LanguageResolver, is_within_project};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
@@ -21,14 +21,14 @@ impl PythonResolver {
 
         // 1. Check if it's a '.py' file (e.g., /root/my/module/name.py)
         potential_path.set_extension("py");
-        if potential_path.is_file() {
+        if potential_path.is_file() && is_within_project(&potential_path, &self.project_root) {
             return Some(potential_path);
         }
 
         // 2. Check if it's a package (e.g., /root/my/module/name/__init__.py)
         potential_path.set_extension(""); // Unset '.py' before joining
         let init_path = potential_path.join("__init__.py");
-        if init_path.is_file() {
+        if init_path.is_file() && is_within_project(&init_path, &self.project_root) {
             return Some(init_path);
         }
 
@@ -55,7 +55,7 @@ impl PythonResolver {
         // If module_spec is empty, we are importing the package itself (e.g., from . import foo)
         if module_spec.is_empty() {
             let init_path = base_dir.join("__init__.py");
-            return if init_path.is_file() {
+            return if init_path.is_file() && is_within_project(&init_path, &self.project_root) {
                 Some(init_path)
             } else {
                 None
@@ -68,12 +68,12 @@ impl PythonResolver {
 
         // Check for .py file or package
         target_path.set_extension("py");
-        if target_path.is_file() {
+        if target_path.is_file() && is_within_project(&target_path, &self.project_root) {
             return Some(target_path);
         }
         target_path.set_extension("");
         let init_path = target_path.join("__init__.py");
-        if init_path.is_file() {
+        if init_path.is_file() && is_within_project(&init_path, &self.project_root) {
             return Some(init_path);
         }
 
@@ -184,6 +184,22 @@ mod tests {
 
         // Relative
         let resolved = resolver.resolve_import(".non_existent", &from_file);
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn test_relative_import_rejects_parent_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().join("project");
+        let package = project_root.join("api");
+        fs::create_dir_all(&package).unwrap();
+        File::create(package.join("routes.py")).unwrap();
+        File::create(temp_dir.path().join("outside.py")).unwrap();
+
+        let mut resolver = PythonResolver::new();
+        resolver.build_module_map(&[], &project_root);
+
+        let resolved = resolver.resolve_import("...outside", &package.join("routes.py"));
         assert!(resolved.is_none());
     }
 }

--- a/src/core/resolvers/typescript.rs
+++ b/src/core/resolvers/typescript.rs
@@ -1,13 +1,16 @@
-use super::LanguageResolver;
+use super::{LanguageResolver, is_within_project};
 use crate::core::defs::Language;
 use std::collections::HashSet;
 use std::path::{Component, Path, PathBuf};
 
-pub struct TypeScriptResolver;
+#[derive(Default)]
+pub struct TypeScriptResolver {
+    project_root: PathBuf,
+}
 
 impl TypeScriptResolver {
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 
     /// Resolves a relative import path into a full PathBuf
@@ -36,7 +39,7 @@ impl TypeScriptResolver {
 
         for ext in Language::TypeScript.extensions() {
             let path_with_ext = normalized_path.with_extension(ext);
-            if path_with_ext.is_file() {
+            if path_with_ext.is_file() && is_within_project(&path_with_ext, &self.project_root) {
                 return Some(path_with_ext);
             }
         }
@@ -45,7 +48,7 @@ impl TypeScriptResolver {
         if normalized_path.is_dir() {
             for ext in Language::TypeScript.extensions() {
                 let index_path = normalized_path.join(format!("index.{ext}"));
-                if index_path.is_file() {
+                if index_path.is_file() && is_within_project(&index_path, &self.project_root) {
                     return Some(index_path);
                 }
             }
@@ -56,7 +59,9 @@ impl TypeScriptResolver {
 }
 
 impl LanguageResolver for TypeScriptResolver {
-    fn build_module_map(&mut self, _files: &[PathBuf], _project_root: &Path) {}
+    fn build_module_map(&mut self, _files: &[PathBuf], project_root: &Path) {
+        self.project_root = project_root.to_path_buf();
+    }
 
     fn resolve_import(&self, import_path: &str, from_file: &Path) -> Option<PathBuf> {
         if is_local_import(import_path) {
@@ -108,7 +113,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         setup_test_project(&temp_dir);
         let root = temp_dir.path();
-        let resolver = TypeScriptResolver::new();
+        let mut resolver = TypeScriptResolver::new();
+        resolver.build_module_map(&[], root);
 
         // From `main.ts`, import a sibling file `./utils`
         let from_file = root.join("main.ts");
@@ -126,7 +132,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         setup_test_project(&temp_dir);
         let root = temp_dir.path();
-        let resolver = TypeScriptResolver::new();
+        let mut resolver = TypeScriptResolver::new();
+        resolver.build_module_map(&[], root);
         let from_file = root.join("main.ts");
 
         // Import a directory `./components`, which should resolve to `components/index.ts`
@@ -143,7 +150,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         setup_test_project(&temp_dir);
         let root = temp_dir.path();
-        let resolver = TypeScriptResolver::new();
+        let mut resolver = TypeScriptResolver::new();
+        resolver.build_module_map(&[], root);
 
         let from_file = root.join("main.ts");
         let resolved = resolver.resolve_import("./non-existent", &from_file);
@@ -151,6 +159,22 @@ mod tests {
 
         // Test non-relative path which should be ignored
         let resolved = resolver.resolve_import("react", &from_file);
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn test_relative_import_rejects_parent_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().join("project");
+        let source_dir = project_root.join("src");
+        fs::create_dir_all(&source_dir).unwrap();
+        File::create(source_dir.join("main.ts")).unwrap();
+        File::create(temp_dir.path().join("outside.ts")).unwrap();
+
+        let mut resolver = TypeScriptResolver::new();
+        resolver.build_module_map(&[], &project_root);
+
+        let resolved = resolver.resolve_import("../../outside", &source_dir.join("main.ts"));
         assert!(resolved.is_none());
     }
 }


### PR DESCRIPTION
# Pull Request

## Initial Checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

## Related Issue(s)

Closes #146

## Description of Changes

Import targets are now accepted only when their canonical paths remain inside the project root. C++, Python, and TypeScript each have traversal regression coverage, and graph construction also rejects targets absent from the project node map.

Validation: 34 focused resolver tests and the full 109-test suite passed. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `git diff --check` also passed.

<!--do not edit: pr-->