### PR TITLE
[C++] Parse qualified names, destructors, and operator overloads

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -2,3 +2,9 @@ pub mod cpp;
 pub mod python;
 pub mod rust;
 pub mod typescript;
+
+/// Helper function to extract text from a node.
+#[inline]
+pub fn get_text(n: tree_sitter::Node, code: &str) -> String {
+    n.utf8_text(code.as_bytes()).unwrap_or("").to_string()
+}

--- a/src/parsers/cpp.rs
+++ b/src/parsers/cpp.rs
@@ -1,14 +1,10 @@
 use crate::core::defs::{FileNode, Import, Language};
+use crate::parsers::get_text;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use tree_sitter::Parser;
 use tree_sitter_cpp as ts_cpp;
-
-/// Helper function to get node text
-fn get_text(n: tree_sitter::Node, code: &str) -> String {
-    n.utf8_text(code.as_bytes()).unwrap_or("").to_string()
-}
 
 /// Determine if an include is local (quoted) vs system (angle brackets)
 #[allow(dead_code)]

--- a/src/parsers/cpp.rs
+++ b/src/parsers/cpp.rs
@@ -82,8 +82,7 @@ fn is_system_include(include_path: &str) -> bool {
 /// (pointer/reference return types, template functions, etc.) and the
 /// terminal name itself may be a plain identifier, a qualified name
 /// (`ns::f`), a destructor (`~Foo`), an operator overload (`operator==`),
-/// or a conversion operator (`operator bool`, which has no name node at
-/// all — only a `type` field).
+/// or a conversion operator (`operator bool`).
 fn extract_declarator_name(node: tree_sitter::Node, code: &str) -> Option<String> {
     match node.kind() {
         "identifier"

--- a/src/parsers/cpp.rs
+++ b/src/parsers/cpp.rs
@@ -80,7 +80,47 @@ fn is_system_include(include_path: &str) -> bool {
     STDLIB_HEADERS.contains(&header_name)
 }
 
-/// Extract include path from #include directive
+/// Recursively resolve a function's declarator down to its name.
+///
+/// The C++ grammar wraps the name node in various declarator shapes
+/// (pointer/reference return types, template functions, etc.) and the
+/// terminal name itself may be a plain identifier, a qualified name
+/// (`ns::f`), a destructor (`~Foo`), an operator overload (`operator==`),
+/// or a conversion operator (`operator bool`, which has no name node at
+/// all — only a `type` field).
+fn extract_declarator_name(node: tree_sitter::Node, code: &str) -> Option<String> {
+    match node.kind() {
+        "identifier"
+        | "field_identifier"
+        | "qualified_identifier"
+        | "destructor_name"
+        | "operator_name" => Some(get_text(node, code)),
+        "operator_cast" => {
+            let type_node = node.child_by_field_name("type")?;
+            Some(format!("operator {}", get_text(type_node, code)))
+        }
+        "function_declarator" => {
+            extract_declarator_name(node.child_by_field_name("declarator")?, code)
+        }
+        "template_function" => extract_declarator_name(node.child_by_field_name("name")?, code),
+        // these wrapping declarators don't expose
+        // their inner declarator through a named field, so search their
+        // named children for the first one that resolves to a name
+        "pointer_declarator"
+        | "reference_declarator"
+        | "array_declarator"
+        | "parenthesized_declarator"
+        | "attributed_declarator"
+        | "structured_binding_declarator" => {
+            let mut cursor = node.walk();
+            node.named_children(&mut cursor)
+                .find_map(|child| extract_declarator_name(child, code))
+        }
+        _ => None,
+    }
+}
+
+/// Extract include path from #include directive.
 fn extract_include_path(node: tree_sitter::Node, code: &str) -> Option<(String, bool)> {
     // For #include directives, the structure is:
     // preproc_include -> string_literal or system_lib_string
@@ -193,7 +233,6 @@ pub fn parse_cpp_file<P: AsRef<Path>>(path: P) -> Option<FileNode> {
     let external_references = HashSet::new();
 
     // Traverse the syntax tree
-    let mut cursor = root_node.walk();
     let mut stack = vec![root_node];
 
     while let Some(node) = stack.pop() {
@@ -212,17 +251,10 @@ pub fn parse_cpp_file<P: AsRef<Path>>(path: P) -> Option<FileNode> {
             }
             "function_definition" => {
                 // Extract function name
-                if let Some(declarator_node) = node
-                    .children(&mut cursor)
-                    .find(|n| n.kind() == "function_declarator")
+                if let Some(declarator_node) = node.child_by_field_name("declarator")
+                    && let Some(name) = extract_declarator_name(declarator_node, &code)
                 {
-                    let mut decl_cursor = declarator_node.walk();
-                    for child in declarator_node.children(&mut decl_cursor) {
-                        if child.kind() == "identifier" {
-                            functions.insert(get_text(child, &code));
-                            break;
-                        }
-                    }
+                    functions.insert(name);
                 }
             }
             "class_specifier" | "struct_specifier" | "union_specifier" => {
@@ -367,6 +399,135 @@ void hello_world() {
         let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
         // Should extract nested includes
         assert_eq!(result.imports().len(), 2);
+    }
+
+    #[test]
+    fn test_extract_qualified_function_name() {
+        let content = r#"
+namespace ns {
+    void f();
+}
+void ns::f() {}
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("ns::f"),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_destructor_name() {
+        let content = r#"
+struct Foo {
+    ~Foo();
+};
+Foo::~Foo() {}
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("Foo::~Foo"),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_inline_destructor_name() {
+        let content = r#"
+struct Foo {
+    ~Foo() {}
+};
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("~Foo"),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_operator_overload_name() {
+        let content = r#"
+struct Foo {
+    bool operator==(const Foo& other) const { return true; }
+};
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("operator=="),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_qualified_operator_overload_name() {
+        let content = r#"
+struct Foo {
+    bool operator==(const Foo& other) const;
+};
+bool Foo::operator==(const Foo& other) const { return true; }
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("Foo::operator=="),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_conversion_operator_name() {
+        let content = r#"
+struct Foo {
+    operator bool() const { return true; }
+};
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("operator bool"),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_reference_wrapped_function_name() {
+        let content = r#"
+struct Foo {
+    Foo& operator=(const Foo& other) { return *this; }
+};
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("operator="),
+            "functions: {:?}",
+            result.functions()
+        );
+    }
+
+    #[test]
+    fn test_extract_pointer_return_function_name() {
+        let content = r#"
+int* make_int() { return nullptr; }
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+        assert!(
+            result.functions().contains("make_int"),
+            "functions: {:?}",
+            result.functions()
+        );
     }
 
     #[test]

--- a/src/parsers/python.rs
+++ b/src/parsers/python.rs
@@ -1,14 +1,10 @@
 use crate::core::defs::{FileNode, Import, Language};
+use crate::parsers::get_text;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use tree_sitter::Parser;
 use tree_sitter_python as ts_python;
-
-/// Helper function to get node text
-fn get_text(n: tree_sitter::Node, code: &str) -> String {
-    n.utf8_text(code.as_bytes()).unwrap_or("").to_string()
-}
 
 /// Determine if an import is local
 fn is_local_import(import_path: &str, file_path: &Path) -> bool {

--- a/src/parsers/rust.rs
+++ b/src/parsers/rust.rs
@@ -1,15 +1,10 @@
 use crate::core::defs::{FileNode, Import, Language};
+use crate::parsers::get_text;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use tree_sitter::Parser;
 use tree_sitter_rust as ts_rust;
-
-/// Get node text.
-#[inline]
-fn get_text(n: tree_sitter::Node, code: &str) -> String {
-    n.utf8_text(code.as_bytes()).unwrap_or("").to_string()
-}
 
 /// Determine if an import is local (starts with crate/self/super or current mod).
 fn is_local_import(import_path: &str, file_path: &Path) -> bool {

--- a/src/parsers/typescript.rs
+++ b/src/parsers/typescript.rs
@@ -1,14 +1,10 @@
 use crate::core::defs::{FileNode, Import, Language};
+use crate::parsers::get_text;
 use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use tree_sitter::Parser;
 use tree_sitter_typescript as ts_typescript;
-
-/// Get node text
-fn get_text(n: tree_sitter::Node, code: &str) -> String {
-    n.utf8_text(code.as_bytes()).unwrap_or("").to_string()
-}
 
 /// Local imports are typically relative paths starting with '.'
 fn is_local_import(import_path: &str) -> bool {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

# Pull Request

## Initial Checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

## Related Issue(s)

#149 

## Description of Changes

- Parse more AST node types, including qualified names, destructors (`~Example`), operator overloads (`operator==`), or conversion operators (`operator bool`)
- Consolidate node text helper

<!--do not edit: pr-->
