### PR TITLE
[C++] Parse macro-wrapped includes

### DIFF
--- a/src/parsers/cpp.rs
+++ b/src/parsers/cpp.rs
@@ -182,7 +182,6 @@ const MACRO_INCLUDE_PATTERNS: &[&str] = &[
 ];
 
 /// Extract includes from common macro patterns
-#[allow(dead_code)]
 fn extract_macro_includes(code: &str) -> HashSet<Import> {
     let mut includes = HashSet::new();
 
@@ -222,7 +221,7 @@ pub fn parse_cpp_file<P: AsRef<Path>>(path: P) -> Option<FileNode> {
     let tree = parser.parse(&code, None)?;
     let root_node = tree.root_node();
 
-    let mut imports = HashSet::new();
+    let mut imports = extract_macro_includes(&code);
     let mut functions = HashSet::new();
     let mut containers = HashSet::new();
     let mut external_references = HashSet::new();
@@ -355,6 +354,28 @@ void hello_world() {
         let temp_file = create_test_file(content);
         let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
         assert_eq!(result.imports().len(), 1);
+    }
+
+    #[test]
+    fn test_extract_macro_includes_through_parser() {
+        let content = r#"
+BOOST_INCLUDE("utility.hpp")
+SYSTEM_INCLUDE(<vector>)
+"#;
+        let temp_file = create_test_file(content);
+        let result = parse_cpp_file(temp_file.path()).expect("Failed to parse");
+
+        assert_eq!(result.imports().len(), 2);
+        assert!(
+            result
+                .imports()
+                .contains(&Import::new("utility.hpp".to_string(), true))
+        );
+        assert!(
+            result
+                .imports()
+                .contains(&Import::new("vector".to_string(), false))
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Pull Request

This pull request was prepared and submitted by an autonomous OpenAI Codex agent using the `LunaMeerkats` account.

## Initial Checklist

* [x] I read the support docs
* [x] I read the contributing guide
* [x] I agree to follow the code of conduct
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

## Related Issue(s)

Closes #151

## Description of Changes

`extract_macro_includes` already recognizes the documented quoted and angle-bracket macro forms, but `parse_cpp_file` discarded its result. This seeds the parser's `imports` set from that helper before tree-sitter traversal, so macro-wrapped and ordinary includes share the existing `HashSet` deduplication path.

The new end-to-end regression passes `BOOST_INCLUDE("utility.hpp")` and `SYSTEM_INCLUDE(<vector>)` through `parse_cpp_file` and asserts their exact local/system `Import` values. With only the test added on `main` commit `30d6ba`, it failed with 0 imports instead of 2; the final patch passes.

Validation on Windows 11 with Rust/Cargo 1.98.0:

- `cargo test parsers::cpp::tests::test_extract_macro_includes_through_parser -- --exact --nocapture` — 1 passed
- `cargo test parsers::cpp::tests -- --nocapture` — 24 passed
- `cargo test` — 142 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy -- -D warnings` — passed
- `cargo check --all-features` — passed
- `git diff --check` — passed

`cargo tarpaulin` is not installed or supported in this Windows environment, so the repository's hosted Ubuntu coverage job remains an explicit publication gate.

This deliberately does not rewrite the existing line-based macro heuristic. Its documented supported forms are restored end to end; broader tokenization and false-positive hardening remain outside this issue's narrow wiring scope.

<!--do not edit: pr-->